### PR TITLE
Refined json structure for plantOffered

### DIFF
--- a/backend/customer/Customer.cpp
+++ b/backend/customer/Customer.cpp
@@ -65,7 +65,7 @@ void Customer::setOfferedPlants(const vector<Plant*>& plants)
             {"id", plant->getId()},
             {"category", plant->getPlantCategory()},
             {"variety", plant->getPlantVariety()},
-            {"careLevel", plant->getCareLevel()},
+            {"difficulty", plant->getDifficulty()},
             {"acceptable", plant->isAcceptable() ? "yes" : "no"},
             {"returnable", plant->isReturnable() ? "yes" : "no"}
         };

--- a/backend/game/Game.cpp
+++ b/backend/game/Game.cpp
@@ -296,8 +296,6 @@ void Game::createCustomers(string type, int num)
 
     const Inventory* inventory = manager->getSaleInventory();
     Director director;
-
-    CustomerVisitor* visitor = nullptr;
     mt19937 rng;
 
     vector<string> difficulties = {"easy", "medium", "hard"};

--- a/tests/unitTests.cpp
+++ b/tests/unitTests.cpp
@@ -629,6 +629,8 @@ TEST(BuilderTests, TestPlantOffering)
             ASSERT_TRUE(plant.contains("returnable"));
         }
     }
+
+    cout << customersJson.dump(4) << endl;
     
     delete game;
 }


### PR DESCRIPTION
Id field will be there, just not there as in my testing I was using normal plants and not cloning them and by cloning them the plants will get an id (as intended)

The image is just 1 customer, you can expect something like this:
[ {customer}, {customer}, ...]
where customer is all the customer's data

<img width="475" height="842" alt="image" src="https://github.com/user-attachments/assets/57c42521-17c3-485e-a664-375f54c9c619" />